### PR TITLE
Bumping up the scipy limit since we're no longer building on python 3.7.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ requirements:
     - qtpy >1.3
     - requests
     - rtree >=0.8.2,!=0.9.1
-    - scipy >=1.6.0,<1.8.0
+    - scipy >=1.6.0,<1.9.0
     - shapely >=1.7.1,<1.8.2,<2.0.0
     - taskgraph >=0.11.0
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

We had an issue earlier this year (https://github.com/natcap/invest/issues/880) where the scipy version needed to be pinned. This PR increases the scipy max version to attempt to resolve the `conda-forge` build failure.

<!--
Please add any other relevant info below:
-->
